### PR TITLE
fix: commission errors not detected in Go/No-Go test

### DIFF
--- a/src/screens/tests/GoNoGoTest.tsx
+++ b/src/screens/tests/GoNoGoTest.tsx
@@ -220,7 +220,7 @@ export function GoNoGoTest({ onComplete }: Props) {
       el.removeEventListener("touchstart", onTouch);
       el.removeEventListener("mousedown", onMouse);
     };
-  }, [handleTap]);
+  }, [handleTap, phase]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {


### PR DESCRIPTION
Fixes #14

Mouse/touch listeners were never attached to the tap area because the useEffect dependency array was missing `phase`. The effect ran once on mount when the div did not exist yet, and never re-ran when the running phase began.

Generated with [Claude Code](https://claude.ai/code)