### PR TITLE
feat: add ?fakeScore=N URL parameter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,15 @@ function initScreen(): Screen {
     }
   }
 
+  // Fake score: ?fakeScore=N
+  const fakeScoreParam = params.get("fakeScore");
+  if (fakeScoreParam !== null) {
+    const n = parseInt(fakeScoreParam, 10);
+    if (!isNaN(n) && n >= 0 && n <= 100) {
+      return { type: "results", fakeScore: n };
+    }
+  }
+
   // Shared results: ?r=BASE64
   const rParam = params.get("r");
   if (rParam) {
@@ -271,7 +280,7 @@ function AppInner() {
         <TestScreen testIndex={screen.testIndex} onNext={handleNext} />
       )}
       {screen.type === "results" && (
-        <ResultsScreen onRestart={handleRestart} onViewScoreboard={handleViewScoreboard} isShared={!!screen.isShared} />
+        <ResultsScreen onRestart={handleRestart} onViewScoreboard={handleViewScoreboard} isShared={!!screen.isShared} fakeScore={screen.fakeScore} />
       )}
       {screen.type === "scoreboard" && (
         <ScoreboardScreen onBack={handleBackFromScoreboard} />

--- a/src/screens/ResultsScreen.tsx
+++ b/src/screens/ResultsScreen.tsx
@@ -12,6 +12,7 @@ interface ResultsScreenProps {
   onRestart: () => void;
   onViewScoreboard: () => void;
   isShared?: boolean;
+  fakeScore?: number;
 }
 
 function LeaderboardSubmit({ score }: { score: number }) {
@@ -588,9 +589,9 @@ function TestDetailCard({ detail }: { detail: TestDetail }) {
   );
 }
 
-export function ResultsScreen({ onRestart, onViewScoreboard, isShared = false }: ResultsScreenProps) {
+export function ResultsScreen({ onRestart, onViewScoreboard, isShared = false, fakeScore }: ResultsScreenProps) {
   const scores = calculateScores();
-  const composite = compositeScore(scores);
+  const composite = fakeScore !== undefined ? fakeScore : compositeScore(scores);
   const details = buildDetails(scores);
   const testsCompleted = Object.values(scores).filter((v) => v !== null).length;
   const selfReport = resultsStore.getItem("selfReport");
@@ -670,10 +671,10 @@ export function ResultsScreen({ onRestart, onViewScoreboard, isShared = false }:
           </CardContent>
 
           <CardFooter className="flex-col gap-3">
-            {composite !== null && !isShared && testsCompleted === 4 && (
+            {composite !== null && !isShared && fakeScore === undefined && testsCompleted === 4 && (
               <LeaderboardSubmit score={composite} />
             )}
-            {composite !== null && !isShared && testsCompleted < 4 && (
+            {composite !== null && !isShared && fakeScore === undefined && testsCompleted < 4 && (
               <p className="text-xs text-muted-foreground text-center">
                 Complete all 4 tests (no skipping) to submit your score to the leaderboard.
               </p>

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type Screen =
   | { type: "landing" }
   | { type: "questionnaire" }
   | { type: "test"; testIndex: number }
-  | { type: "results"; isShared?: boolean }
+  | { type: "results"; isShared?: boolean; fakeScore?: number }
   | { type: "scoreboard" };
 
 // ── Result types ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a `?fakeScore=N` URL parameter to display a custom score on the results screen, regardless of actual test performance. Leaderboard submission is disabled when using a fake score.

Closes #31

Generated with [Claude Code](https://claude.ai/code)