### PR TITLE
feat: add fake score sharing button on landing screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,6 +225,36 @@ function AppInner() {
 
   const handleStart = () => setScreen({ type: "questionnaire" });
 
+  const handleFlexFakeScore = useCallback(async () => {
+    const fakeScores = { sart: 0, stroop: 100, pvt: 60, gonogo: 36 };
+    const composite = compositeScore(fakeScores);
+    if (composite === null) return;
+    const rank = getRank(composite);
+    const blob = await generateScoreImage(composite, rank.badge, rank.summary, fakeScores);
+    if (!blob) {
+      toast.error("Could not generate image.");
+      return;
+    }
+    const file = new File([blob], "brainrot-score.png", { type: "image/png" });
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "My Brainrot Score", files: [file] });
+        return;
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") return;
+      }
+    }
+    const objectUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = objectUrl;
+    a.download = "brainrot-score.png";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(objectUrl);
+    toast.success("Score image saved — share it on social media!");
+  }, []);
+
   const handleQuestionnaireComplete = () => setScreen({ type: "test", testIndex: 0 });
 
   const handleContinue = () => {
@@ -262,6 +292,7 @@ function AppInner() {
           hasProgress={hasAnyProgress()}
           onContinue={handleContinue}
           onStartOver={handleRestart}
+          onFlexFakeScore={handleFlexFakeScore}
         />
       )}
       {screen.type === "questionnaire" && (

--- a/src/screens/LandingScreen.tsx
+++ b/src/screens/LandingScreen.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Github } from "lucide-react";
+import { Github, Share2 } from "lucide-react";
 import { TEST_LIST } from "@/types";
 
 interface LandingScreenProps {
@@ -8,9 +8,10 @@ interface LandingScreenProps {
   hasProgress: boolean;
   onContinue: () => void;
   onStartOver: () => void;
+  onFlexFakeScore?: () => void;
 }
 
-export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver }: LandingScreenProps) {
+export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver, onFlexFakeScore }: LandingScreenProps) {
   return (
     <div
       className="flex min-h-svh flex-col items-center justify-center p-4"
@@ -47,6 +48,12 @@ export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver }:
             <p className="text-xs text-muted-foreground text-center">
               ~15-20 min. Put your phone down. Yes, that one. The test won't feel fair if you're half-scrolling.
             </p>
+            {onFlexFakeScore && (
+              <Button className="w-full gap-2" size="lg" variant="secondary" onClick={onFlexFakeScore}>
+                <Share2 className="h-5 w-5 shrink-0" />
+                <span>Flex my score</span>
+              </Button>
+            )}
             {hasProgress ? (
               <>
                 <Button className="w-full" size="lg" onClick={onContinue}>


### PR DESCRIPTION
Adds a "Flex my score" button on the landing screen that generates and shares a score image with predefined fake scores (Test 1: 0, Test 2: 100, Test 3: 60, Test 4: 36).

Closes #34

Generated with [Claude Code](https://claude.ai/code)