### PR TITLE
fix: download image on Windows instead of share sheet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,7 +124,9 @@ function ShareFAB() {
     const file = new File([blob], "brainrot-score.png", { type: "image/png" });
 
     // Mobile: Web Share API with file support (iOS and Android Chrome 86+)
-    if (navigator.share) {
+    // Skip on Windows — the native share UI is poor; download instead
+    const isWindows = /Windows/i.test(navigator.userAgent);
+    if (navigator.share && !isWindows) {
       try {
         await navigator.share({ title: "My Brainrot Score", files: [file] });
         return;


### PR DESCRIPTION
On Windows, skip the native Web Share API and download the score image directly, since the Windows share UI is not well-suited for this use case.

Related to #26

Generated with [Claude Code](https://claude.ai/code)