### PR TITLE
🚸 Add client-side routing with browser history support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -359,11 +359,7 @@ function AppInner() {
     setScreen({ type: "landing" });
   };
 
-  const handleViewScoreboard = () => navigate({ type: "scoreboard", from: "results" });
-  const handleViewScoreboardFromLanding = () => navigate({ type: "scoreboard", from: "landing" });
   const handleBackFromScoreboard = () => history.back();
-
-  const handleViewStats = () => navigate({ type: "stats" });
   const handleBackFromStats = () => history.back();
 
   return (
@@ -374,8 +370,6 @@ function AppInner() {
           hasProgress={hasAnyProgress()}
           onContinue={handleContinue}
           onStartOver={handleRestart}
-          onViewScoreboard={handleViewScoreboardFromLanding}
-          onViewStats={handleViewStats}
           isReturningVisitor={!!returningSurvey}
         />
       )}
@@ -386,7 +380,7 @@ function AppInner() {
         <TestScreen testIndex={screen.testIndex} onNext={handleNext} />
       )}
       {screen.type === "results" && (
-        <ResultsScreen onRestart={handleRestart} onViewScoreboard={handleViewScoreboard} isShared={!!screen.isShared} />
+        <ResultsScreen onRestart={handleRestart} isShared={!!screen.isShared} />
       )}
       {screen.type === "scoreboard" && (
         <ScoreboardScreen onBack={handleBackFromScoreboard} />

--- a/src/__tests__/screens.test.tsx
+++ b/src/__tests__/screens.test.tsx
@@ -32,13 +32,15 @@ describe("LandingScreen", () => {
   afterEach(() => { cleanup(); });
 
   test("shows title and start button", () => {
-    render(<LandingScreen onStart={jest.fn()} hasProgress={false} onContinue={jest.fn()} onStartOver={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<LandingScreen onStart={jest.fn()} hasProgress={false} onContinue={jest.fn()} onStartOver={jest.fn()} />
+);
     expect(screen.getByText("Brainrot Meter")).toBeInTheDocument();
     expect(screen.getByText("Check my brainrot")).toBeInTheDocument();
   });
 
   test("shows test list", () => {
-    render(<LandingScreen onStart={jest.fn()} hasProgress={false} onContinue={jest.fn()} onStartOver={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<LandingScreen onStart={jest.fn()} hasProgress={false} onContinue={jest.fn()} onStartOver={jest.fn()} />
+);
     expect(screen.getByText("Sustained Attention (SART)")).toBeInTheDocument();
     expect(screen.getByText("Stroop Color-Word")).toBeInTheDocument();
     expect(screen.getByText("Psychomotor Vigilance (PVT)")).toBeInTheDocument();
@@ -47,13 +49,15 @@ describe("LandingScreen", () => {
 
   test("calls onStart when clicking start button", () => {
     const onStart = jest.fn();
-    render(<LandingScreen onStart={onStart} hasProgress={false} onContinue={jest.fn()} onStartOver={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<LandingScreen onStart={onStart} hasProgress={false} onContinue={jest.fn()} onStartOver={jest.fn()} />
+);
     fireEvent.click(screen.getByText("Check my brainrot"));
     expect(onStart).toHaveBeenCalledTimes(1);
   });
 
   test("shows continue and start over buttons when has progress", () => {
-    render(<LandingScreen onStart={jest.fn()} hasProgress={true} onContinue={jest.fn()} onStartOver={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<LandingScreen onStart={jest.fn()} hasProgress={true} onContinue={jest.fn()} onStartOver={jest.fn()} />
+);
     expect(screen.getByText("Continue where you left off")).toBeInTheDocument();
     expect(screen.getByText("Start over")).toBeInTheDocument();
   });
@@ -61,7 +65,8 @@ describe("LandingScreen", () => {
   test("calls onContinue and onStartOver correctly", () => {
     const onContinue = jest.fn();
     const onStartOver = jest.fn();
-    render(<LandingScreen onStart={jest.fn()} hasProgress={true} onContinue={onContinue} onStartOver={onStartOver} onViewScoreboard={jest.fn()} />);
+    render(<LandingScreen onStart={jest.fn()} hasProgress={true} onContinue={onContinue} onStartOver={onStartOver} />
+);
 
     fireEvent.click(screen.getByText("Continue where you left off"));
     expect(onContinue).toHaveBeenCalledTimes(1);
@@ -234,7 +239,8 @@ describe("ResultsScreen", () => {
   });
 
   test("shows 'No results yet' when no tests completed", () => {
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={jest.fn()} />
+);
     expect(screen.getByText("No results yet")).toBeInTheDocument();
   });
 
@@ -244,7 +250,8 @@ describe("ResultsScreen", () => {
     resultsStore.setItem("pvt", goodPvt);
     resultsStore.setItem("gonogo", goodGonogo);
 
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={jest.fn()} />
+);
 
     expect(screen.getByText("Attention Score")).toBeInTheDocument();
     expect(screen.getByText("Based on 4 of 4 tests")).toBeInTheDocument();
@@ -252,19 +259,21 @@ describe("ResultsScreen", () => {
 
   test("shows test detail cards for completed tests", () => {
     resultsStore.setItem("sart", goodSart);
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={jest.fn()} />
+);
     expect(screen.getByText("Sustained Attention (SART)")).toBeInTheDocument();
   });
 
   test("shows skipped card for skipped tests", () => {
     resultsStore.setItem("sart", { skipped: true });
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={jest.fn()} />
+);
     expect(screen.getByText("Skipped")).toBeInTheDocument();
   });
 
   test("shows shared results banner when isShared", () => {
     resultsStore.setItem("sart", goodSart);
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} isShared={true} />);
+    render(<ResultsScreen onRestart={jest.fn()} isShared={true} />);
     expect(screen.getByText("You're viewing someone else's results")).toBeInTheDocument();
     expect(screen.getByText("Take the test yourself →")).toBeInTheDocument();
   });
@@ -272,17 +281,18 @@ describe("ResultsScreen", () => {
   test("restart button calls onRestart", () => {
     resultsStore.setItem("sart", goodSart);
     const onRestart = jest.fn();
-    render(<ResultsScreen onRestart={onRestart} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={onRestart} />
+);
     fireEvent.click(screen.getByText("Take Test Again"));
     expect(onRestart).toHaveBeenCalledTimes(1);
   });
 
-  test("scoreboard button calls onViewScoreboard", () => {
+  test("scoreboard link has correct href", () => {
     resultsStore.setItem("sart", goodSart);
-    const onViewScoreboard = jest.fn();
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={onViewScoreboard} />);
-    fireEvent.click(screen.getByText("View Scoreboard"));
-    expect(onViewScoreboard).toHaveBeenCalledTimes(1);
+    render(<ResultsScreen onRestart={jest.fn()} />);
+    const link = screen.getByText("View Scoreboard").closest("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("/scoreboard");
   });
 
   test("shows self-report context when selfReport and composite exist", () => {
@@ -294,7 +304,8 @@ describe("ResultsScreen", () => {
       selfRatedAttention: 4,
       screenTime: "Less than 2 hrs",
     });
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={jest.fn()} />
+);
     expect(screen.getByText("Your self-report context")).toBeInTheDocument();
   });
 
@@ -303,7 +314,7 @@ describe("ResultsScreen", () => {
     resultsStore.setItem("stroop", goodStroop);
     resultsStore.setItem("pvt", goodPvt);
     resultsStore.setItem("gonogo", goodGonogo);
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} isShared={false} />);
+    render(<ResultsScreen onRestart={jest.fn()} isShared={false} />);
     expect(screen.getByText("Submit to Scoreboard")).toBeInTheDocument();
   });
 
@@ -325,7 +336,7 @@ describe("ResultsScreen", () => {
     const originalFetch = global.fetch;
     global.fetch = jest.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
 
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} isShared={false} />);
+    render(<ResultsScreen onRestart={jest.fn()} isShared={false} />);
 
     // Should show auto-submitting message with the nickname
     expect(screen.getByText(/AutoPlayer/)).toBeInTheDocument();
@@ -345,7 +356,7 @@ describe("ResultsScreen", () => {
     const originalFetch = global.fetch;
     global.fetch = jest.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
 
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} isShared={false} />);
+    render(<ResultsScreen onRestart={jest.fn()} isShared={false} />);
 
     expect(screen.getByText("Loading leaderboard...")).toBeInTheDocument();
 
@@ -361,7 +372,7 @@ describe("ResultsScreen", () => {
     const originalFetch = global.fetch;
     global.fetch = jest.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
 
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} isShared={true} />);
+    render(<ResultsScreen onRestart={jest.fn()} isShared={true} />);
 
     expect(screen.queryByText("Loading leaderboard...")).not.toBeInTheDocument();
 
@@ -373,14 +384,15 @@ describe("ResultsScreen", () => {
     resultsStore.setItem("stroop", goodStroop);
     resultsStore.setItem("pvt", goodPvt);
     resultsStore.setItem("gonogo", goodGonogo);
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} isShared={true} />);
+    render(<ResultsScreen onRestart={jest.fn()} isShared={true} />);
     expect(screen.queryByText("Submit to Scoreboard")).not.toBeInTheDocument();
   });
 
   test("shows partial results message when not all tests completed", () => {
     resultsStore.setItem("sart", goodSart);
     resultsStore.setItem("stroop", { skipped: true });
-    render(<ResultsScreen onRestart={jest.fn()} onViewScoreboard={jest.fn()} />);
+    render(<ResultsScreen onRestart={jest.fn()} />
+);
     expect(screen.getByText(/Complete all 4 tests/)).toBeInTheDocument();
   });
 });

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+/**
+ * A client-side navigation link that renders as a proper <a> element with href.
+ * Intercepts clicks to prevent full page reloads and instead uses the History API,
+ * dispatching a popstate event so App-level routing picks up the new location.
+ *
+ * Usage with Button asChild:
+ *   <Button asChild variant="ghost"><Link href="/scoreboard">Scoreboard</Link></Button>
+ */
+export function Link({
+  href,
+  onClick,
+  children,
+  ...props
+}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // Let modifier keys / middle-click open in new tab naturally
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+      return;
+    }
+    e.preventDefault();
+    if (window.location.pathname !== href) {
+      window.history.pushState({}, "", href);
+      // Notify App's popstate listener so it syncs React state
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
+    onClick?.(e);
+  };
+
+  return (
+    <a href={href} onClick={handleClick} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/src/screens/LandingScreen.tsx
+++ b/src/screens/LandingScreen.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Link } from "@/components/ui/link";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Github, Trophy, BarChart2 } from "lucide-react";
 import { TEST_LIST } from "@/types";
@@ -9,12 +10,10 @@ interface LandingScreenProps {
   hasProgress: boolean;
   onContinue: () => void;
   onStartOver: () => void;
-  onViewScoreboard: () => void;
-  onViewStats?: () => void;
   isReturningVisitor?: boolean;
 }
 
-export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver, onViewScoreboard, onViewStats, isReturningVisitor }: LandingScreenProps) {
+export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver, isReturningVisitor }: LandingScreenProps) {
   const [giveUpCount, setGiveUpCount] = useState<number | null>(null);
 
   useEffect(() => {
@@ -91,16 +90,18 @@ export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver, o
                 Check my brainrot
               </Button>
             )}
-            <Button className="w-full gap-2" size="sm" variant="ghost" onClick={onViewScoreboard}>
-              <Trophy className="h-4 w-4" />
-              Scoreboard
+            <Button asChild className="w-full gap-2" size="sm" variant="ghost">
+              <Link href="/scoreboard">
+                <Trophy className="h-4 w-4" />
+                Scoreboard
+              </Link>
             </Button>
-            {onViewStats && (
-              <Button className="w-full gap-2" size="sm" variant="ghost" onClick={onViewStats}>
+            <Button asChild className="w-full gap-2" size="sm" variant="ghost">
+              <Link href="/stats">
                 <BarChart2 className="h-4 w-4" />
                 Human Behaviour Stats
-              </Button>
-            )}
+              </Link>
+            </Button>
           </CardFooter>
         </Card>
       </div>

--- a/src/screens/ResultsScreen.tsx
+++ b/src/screens/ResultsScreen.tsx
@@ -3,6 +3,7 @@ import { resultsStore } from "@/utils/resultsStore";
 import { getVisitorId } from "@/utils/visitorId";
 import { ChevronDown, ChevronUp, Trophy, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Link } from "@/components/ui/link";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
@@ -11,7 +12,6 @@ import type { SARTStats, StroopStats, PVTStats, GoNoGoStats, SelfReportData, Ski
 
 interface ResultsScreenProps {
   onRestart: () => void;
-  onViewScoreboard: () => void;
   isShared?: boolean;
 }
 
@@ -20,7 +20,7 @@ interface LeaderboardEntry {
   score: number;
 }
 
-function MiniLeaderboard({ userScore, userName, onViewFull }: { userScore: number; userName?: string; onViewFull: () => void }) {
+function MiniLeaderboard({ userScore, userName }: { userScore: number; userName?: string }) {
   const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -107,9 +107,11 @@ function MiniLeaderboard({ userScore, userName, onViewFull }: { userScore: numbe
         </table>
       </div>
       <p className="text-xs text-muted-foreground text-center">#{rank} out of ~{total} players</p>
-      <Button variant="outline" size="sm" className="w-full gap-2" onClick={onViewFull}>
-        <ExternalLink className="w-3 h-3" />
-        View full scoreboard
+      <Button asChild variant="outline" size="sm" className="w-full gap-2">
+        <Link href="/scoreboard">
+          <ExternalLink className="w-3 h-3" />
+          View full scoreboard
+        </Link>
       </Button>
     </div>
   );
@@ -718,7 +720,7 @@ function TestDetailCard({ detail }: { detail: TestDetail }) {
   );
 }
 
-export function ResultsScreen({ onRestart, onViewScoreboard, isShared = false }: ResultsScreenProps) {
+export function ResultsScreen({ onRestart, isShared = false }: ResultsScreenProps) {
   const scores = calculateScores();
   const composite = compositeScore(scores);
   const details = buildDetails(scores);
@@ -805,7 +807,7 @@ export function ResultsScreen({ onRestart, onViewScoreboard, isShared = false }:
               <LeaderboardSubmit score={composite} onSuccess={(name) => setSubmittedName(name)} />
             )}
             {composite !== null && !isShared && testsCompleted === 4 && (
-              <MiniLeaderboard userScore={composite} userName={submittedName} onViewFull={onViewScoreboard} />
+              <MiniLeaderboard userScore={composite} userName={submittedName} />
             )}
             {composite !== null && !isShared && testsCompleted < 4 && (
               <p className="text-xs text-muted-foreground text-center">
@@ -813,9 +815,11 @@ export function ResultsScreen({ onRestart, onViewScoreboard, isShared = false }:
               </p>
             )}
             {(composite === null || isShared || testsCompleted < 4) && (
-              <Button variant="secondary" className="w-full font-semibold gap-2" size="lg" onClick={onViewScoreboard}>
-                <Trophy className="w-4 h-4" />
-                View Scoreboard
+              <Button asChild variant="secondary" className="w-full font-semibold gap-2" size="lg">
+                <Link href="/scoreboard">
+                  <Trophy className="w-4 h-4" />
+                  View Scoreboard
+                </Link>
               </Button>
             )}
             <Button className="w-full" size="lg" onClick={onRestart}>


### PR DESCRIPTION
Adds URL-based routing to the SPA using the History API.

- Navigating to Scoreboard or Stats from the landing page now updates the URL to `/scoreboard` or `/stats`
- Pressing the browser back button returns to the previous page as expected
- Direct URL access to `/scoreboard`, `/stats`, or `/results` works

Closes #54

Generated with [Claude Code](https://claude.ai/code)