### PR TITLE
Rename "Human Behaviour Stats/Data" to "Stats"

### DIFF
--- a/src/screens/LandingScreen.tsx
+++ b/src/screens/LandingScreen.tsx
@@ -99,7 +99,7 @@ export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver, i
             <Button asChild className="w-full gap-2" size="sm" variant="ghost">
               <Link href="/stats">
                 <BarChart2 className="h-4 w-4" />
-                Human Behaviour Stats
+                Stats
               </Link>
             </Button>
           </CardFooter>

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -683,7 +683,7 @@ export function StatsScreen({ onBack }: StatsScreenProps) {
             Back
           </Button>
           <div className="text-center space-y-2">
-            <h1 className="text-3xl font-bold tracking-tight">Human Behaviour Data</h1>
+            <h1 className="text-3xl font-bold tracking-tight">Stats</h1>
             <p className="text-muted-foreground text-sm max-w-lg mx-auto">
               Aggregated results from all visitors — anonymised, cross-referenced with demographics.
               A live study of attention in the age of short-form content.


### PR DESCRIPTION
Renames confusing labels "Human Behaviour Stats" and "Human Behaviour Data" to simply "Stats".

Closes #65

Generated with [Claude Code](https://claude.ai/code)