### PR TITLE
fix: add skeleton to visitor counter to prevent layout jump

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/screens/LandingScreen.tsx
+++ b/src/screens/LandingScreen.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Link } from "@/components/ui/link";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Github, Trophy, BarChart2 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TEST_LIST } from "@/types";
 
 interface LandingScreenProps {
@@ -58,16 +59,23 @@ export function LandingScreen({ onStart, hasProgress, onContinue, onStartOver, i
             </ul>
           </CardContent>
           <CardFooter className="flex-col gap-3">
-            {giveUpCount !== null && (
-              <div className="w-full rounded-lg border border-muted-foreground/20 bg-muted/40 px-4 py-3 text-center">
-                <p className="text-2xl font-black text-foreground/70">
-                  {giveUpCount.toLocaleString()}
-                </p>
-                <p className="text-xs font-medium text-muted-foreground mt-0.5">
-                  people have given up on this test
-                </p>
-              </div>
-            )}
+            <div className="w-full rounded-lg border border-muted-foreground/20 bg-muted/40 px-4 py-3 text-center">
+              {giveUpCount === null ? (
+                <div className="flex flex-col items-center gap-1.5">
+                  <Skeleton className="h-8 w-16" />
+                  <Skeleton className="h-3 w-44" />
+                </div>
+              ) : (
+                <>
+                  <p className="text-2xl font-black text-foreground/70">
+                    {giveUpCount.toLocaleString()}
+                  </p>
+                  <p className="text-xs font-medium text-muted-foreground mt-0.5">
+                    people have given up on this test
+                  </p>
+                </>
+              )}
+            </div>
             <p className="text-xs text-muted-foreground text-center">
               ~15-20 min. Put your phone down. Yes, that one. The test won't feel fair if you're half-scrolling.
             </p>


### PR DESCRIPTION
Fixes #77

The visitor counter was only rendered after async data loaded, causing buttons below it to shift position. Now the container is always rendered with skeleton placeholders matching the content dimensions while loading.

Generated with [Claude Code](https://claude.ai/code)